### PR TITLE
docs(install): listmonk-синтаксис подстановок в шаблонах писем

### DIFF
--- a/src/install/FULL_INSTALL.md
+++ b/src/install/FULL_INSTALL.md
@@ -377,21 +377,30 @@ LISTMONK_PASSWORD=api-token-here  # API токен
 
 #### Шаблоны писем
 
-Создайте шаблоны писем в listmonk по данным темам, используйте подстановку в шаблонах и зафиксируйте ID шаблона:
+Создайте шаблоны писем в listmonk по данным темам и зафиксируйте ID каждого шаблона в админке Stormbpmn.
+
+::: warning Синтаксис подстановок
+Listmonk использует синтаксис Go-шаблонов: переменные доступны через `{{ .Tx.Data.имя }}`, а не `{имя}`. Например, `{{ .Tx.Data.diagram_name }}`.
+:::
 
 ![Шаблоны](list_monk_4.png)
 
-| Тип уведомления                         | Настройка в админке                  | Возможные подстановки                                                  |
-| --------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------- |
-| **Новый комментарий**                   | `commentEmailTemplateId`             | `{comment_author}`, `{diagram_name}`, `{diagram_url}`, `{html_text}`   |
-| **Запрос на согласование**              | `approvalTemplateId`                 | `{invite_author}`, `{diagram_name}`, `{diagram_url}`                   |
-| **Восстановление пароля**               | `restorePasswordTemplateId`          | `{restoreCode}`                                                        |
-| **Согласование завершено**              | `approvalCompletedTemplateId`        | `{diagram_name}`, `{diagram_url}`                                      |
-| **Активация пользователя**              | `userActivationTemplateId`           | `{activation_token}`                                                   |
-| **Приглашение к диаграмме**             | `secureUpdateTemplateId`             | `{invite_author}`, `{diagram_name}`, `{diagram_url}`                   |
-| **Приглашение + регистрация**           | `inviteDiagramAndRegisterTemplateId` | `{invite_author}`, `{diagram_name}`, `{diagram_url}`, `{register_url}` |
-| **Приглашение в команду**               | `teamInviteTemplateId`               | `{invite_author}`, `{team_name}`                                       |
-| **Приглашение в команду + регистрация** | `teamInviteAndRegisterTemplateId`    | `{invite_author}`, `{team_name}`, `{register_url}`                     |
+| Тип уведомления                         | Настройка в админке                  | Возможные подстановки                                                                                                       |
+| --------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **Новый комментарий**                   | `commentEmailTemplateId`             | `{{ .Tx.Data.comment_author }}`, `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`, `{{ .Tx.Data.html_text }}`     |
+| **Запрос на согласование**              | `approvalTemplateId`                 | `{{ .Tx.Data.invite_author }}`, `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`                                 |
+| **Восстановление пароля**               | `restorePasswordTemplateId`          | `{{ .Tx.Data.restoreCode }}`                                                                                                |
+| **Согласование завершено**              | `approvalCompletedTemplateId`        | `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`                                                                 |
+| **Активация пользователя**              | `userActivationTemplateId`           | `{{ .Tx.Data.activation_token }}`                                                                                           |
+| **Приглашение к диаграмме**             | `secureUpdateTemlateId`              | `{{ .Tx.Data.invite_author }}`, `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`                                 |
+| **Приглашение + регистрация**           | `inviteDiagramAndRegisterTemplateId` | `{{ .Tx.Data.invite_author }}`, `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`, `{{ .Tx.Data.register_url }}`   |
+| **Приглашение в команду**               | `teamInviteTemplateId`               | `{{ .Tx.Data.invite_author }}`, `{{ .Tx.Data.team_name }}`                                                                  |
+| **Приглашение в команду + регистрация** | `teamInviteAndRegisterTemplateId`    | `{{ .Tx.Data.invite_author }}`, `{{ .Tx.Data.team_name }}`, `{{ .Tx.Data.register_url }}`                                   |
+| **Запрос доступа к диаграмме**          | `accessRequestTemplateId`            | `{{ .Tx.Data.requester_name }}`, `{{ .Tx.Data.diagram_name }}`, `{{ .Tx.Data.diagram_url }}`, `{{ .Tx.Data.request_message }}` |
+
+::: tip Опечатка в ключе
+Ключ `secureUpdateTemlateId` указан **с опечаткой намеренно** — именно так он называется в настройках системы (без `p` в `Temlate`).
+:::
 
 #### Укажите ID шаблон в адмнике Stormbpmn
 


### PR DESCRIPTION
## Что и почему

В разделе **Настройка почтовых уведомлений → ListMonk → Шаблоны писем** мануал описывал подстановки в формате `{diagram_name}`. Это формат Mautic / встроенного SMTP-клиента. Listmonk рендерит transactional-шаблоны как Go-шаблоны, и переменные там доступны только через `{{ .Tx.Data.имя }}`. По старому мануалу подстановки в listmonk просто не срабатывали.

## Изменения в `src/install/FULL_INSTALL.md`

- Вся таблица шаблонов переведена на формат `{{ .Tx.Data.x }}`.
- Добавлен callout с пояснением синтаксиса подстановок listmonk.
- Ключ `secureUpdateTemplateId` исправлен на фактический `secureUpdateTemlateId` — в самой системе ключ с опечаткой (`Temlate` без `p`), мануал теперь ей соответствует. Рядом callout, чтобы опечатку не «исправили» обратно.
- Добавлена строка `accessRequestTemplateId` — письмо «Запрос доступа к диаграмме», реальный используемый шаблон, которого в таблице не было.

## Контекст

Источник истины по переменным — значения `params` в местах вызова `emailService.sendEmail(...)` в бэкенде; формат `{{ .Tx.Data.* }}` — то, как `ListmonkEmailService` передаёт их в `POST /api/tx` (поле `data`).

Правки `sm_possible_settings` в репозитории кода намеренно не трогались — это отдельный вопрос.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
