### PR TITLE
feat: AI-помощник по документации

### DIFF
--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -152,6 +152,15 @@ export default defineUserConfig({
             "link",
             { rel: "preload", href: "/assets/fonts/HS_LunaObscura.woff2", as: "font", type: "font/woff2", crossorigin: "" },
         ],
+        // AI-помощник по документации: плавающая кнопка «Спросить AI» (Ctrl/⌘+I), отвечает
+        // строго по содержимому этого сайта и даёт ссылки на разделы.
+        //
+        // Скрипт самодостаточный — ни сборки, ни зависимостей. Ручку он дёргает по адресу
+        // /ai/ask НА ЭТОМ ЖЕ домене (nginx проксирует её в сервис), поэтому запрос
+        // same-origin и CORS не участвует. Ключей в разметке нет и быть не может.
+        //
+        // Горячая клавиша НЕ Ctrl+K: её занимает встроенный поиск (search-pro).
+        ["script", { src: "https://stormbpmn.com/docs-chat/widget.js", defer: "" }],
     ],
 
     theme: hopeTheme({


### PR DESCRIPTION
> [!IMPORTANT]
> **Мержить только после релиза фронта stormbpmn.com.** Сейчас `https://stormbpmn.com/docs-chat/widget.js` отдаёт `200`, но это ловушка: `content-type: text/html`, внутри SPA-заглушка. Файл появится по этому адресу вместе со сборкой фронта. Если влить раньше — скрипт молча не выполнится и кнопки просто не будет.

## Что это

Плавающая кнопка «Спросить AI» (Ctrl/⌘+I) на всех страницах. Отвечает **строго по содержимому этого сайта** и даёт ссылки на конкретные разделы. Если ответа в документации нет — честно говорит об этом, а не выдумывает: при пустом поиске модель вообще не вызывается.

Одна строка в `head`. Скрипт самодостаточный — ни сборки, ни зависимостей, ни ключей в разметке.

## Как устроено

Индекс собирается из **markdown этой репы**, а перестраивается по `Last-Modified` **выложенного сайта**: ваш `deploy-docs.yml` запускается тем же пушем, поэтому «сайт обновился» ⇒ «main == то, что выложено». Правка доезжает до помощника за ≤10 минут после выкладки, руками делать ничего не нужно.

Ручка живёт по `/ai/ask` на **этом же домене** — nginx проксирует её в сервис. Значит запрос same-origin, CORS не участвует, ключей в разметке нет и быть не может.

Горячая клавиша не `Ctrl+K`: её занимает встроенный поиск `search-pro`, отбирать привычное сочетание нельзя.

## Проверено на живом сайте

- Все **36 страниц и 171 якорь**, которые помощник отдаёт как источники, резолвятся на `enterprise.stormbpmn.com`.
- Ручка уже работает: `POST /ai/ask` → ответ со ссылками за ~15 с; `GET` → `403` (запрещён на уровне nginx).
- Посторонний вопрос («рецепт борща») отсекается за 15 мс без обращения к модели.

## Необязательное продолжение

Если в конец `deploy-docs.yml` дописать шаг

```yaml
- name: Обновить индекс AI-помощника
  run: curl -fsS -X POST -H "X-Admin-Token: $TOKEN" http://192.168.0.6:8100/admin/reindex || true
```

индекс будет обновляться за секунды после выкладки вместо ≤10 минут опроса. Не обязательно — без этого всё работает, просто с лагом. Токен могу передать отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vTCsEYabujHFwnAKM8ys
